### PR TITLE
Fix/home page

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,5 +1,6 @@
 import { Routes, Route } from 'react-router-dom';
 
+import HomePage from './pages/HomePage/HomePage';
 import FeedPage from './pages/FeedPage/FeedPage';
 import ProfilePage from './pages/ProfilePage/ProfilePage';
 import PublishIdeaPage from './pages/PublishActivityPage';
@@ -18,7 +19,7 @@ const App = () => {
       <Routes>
         <Route path="/login" element={<LoginPage />} />
         <Route path="/register" element={<RegisterPage />} />
-        <Route path="/" element={<FeedPage />} />
+        <Route path="/" element={<HomePage />} />
         <Route path="/edit-profile" element={<EditProfilePage />} />
         <Route element={<NavOutlet />}>
           <Route path="/feed" element={<FeedPage />} />

--- a/client/src/pages/FeedPage/FeedPage.tsx
+++ b/client/src/pages/FeedPage/FeedPage.tsx
@@ -1,9 +1,7 @@
 import { useState, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
 import { SubmitHandler, useForm } from 'react-hook-form';
 
 import { getNewlyPublishedActivity } from '../../redux/activitySlice';
-import { checkAuthentication } from '../../services/auth';
 import { getFeed } from '../../services/feed';
 import { FeedActivity } from '../../types/feed';
 import FeedItem from '../../components/FeedItem/FeedItem';
@@ -21,26 +19,13 @@ export interface IFormInput {
 }
 
 const FeedPage = () => {
-  const [isAuthenticated, setIsAuthenticated] = useState<boolean>(false);
-  const [hasChecked, setHasChecked] = useState<boolean>(false);
   const [postsByFilter, setPostsByFilter] = useState();
 
   const { control, handleSubmit } = useForm<IFormInput>({});
 
-  const navigate = useNavigate();
-
   const [feedItems, setFeedItems] = useState<FeedActivity[]>([]);
 
   const myNewPublish = getNewlyPublishedActivity();
-
-  useEffect(() => {
-    (async () => {
-      const authRes = await checkAuthentication();
-
-      setIsAuthenticated(authRes);
-      setHasChecked(true);
-    })();
-  }, []);
 
   useEffect(() => {
     const getFeedItems = async () => {
@@ -50,12 +35,6 @@ const FeedPage = () => {
 
     getFeedItems();
   }, []);
-
-  if (hasChecked) {
-    if (!isAuthenticated) {
-      navigate('/login');
-    }
-  }
 
   const onSubmit: SubmitHandler<any> = (data) => {
     const apiEndpoint = 'http://localhost:3000/feed';
@@ -80,18 +59,14 @@ const FeedPage = () => {
 
   return (
     <div className="feed-page">
-      {hasChecked && isAuthenticated && (
-        <>
-          Filter Placeholder
-          <form onSubmit={handleSubmit(onSubmit)}>
-            <FiltersSelect control={control} />
-            <button type="submit">Search</button>
-          </form>
-          {myNewPublish && <FeedItem activity={myNewPublish} />}
-          {!!feedItems.length &&
-            feedItems.map((feedItem) => <FeedItem activity={feedItem} />)}
-        </>
-      )}
+      Filter Placeholder
+      <form onSubmit={handleSubmit(onSubmit)}>
+        <FiltersSelect control={control} />
+        <button type="submit">Search</button>
+      </form>
+      {myNewPublish && <FeedItem activity={myNewPublish} />}
+      {!!feedItems.length &&
+        feedItems.map((feedItem) => <FeedItem activity={feedItem} />)}
     </div>
   );
 };

--- a/client/src/pages/HomePage/HomePage.css
+++ b/client/src/pages/HomePage/HomePage.css
@@ -1,0 +1,31 @@
+.home-page {
+  width: 100%;
+  height: 100%;
+  background-color: var(--primary-color);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  & .spinner-container {
+    width: 10rem;
+    height: 10rem;
+    background-color: var(--secondary-color);
+    border-radius: 50%;
+
+    & img {
+      width: 100%;
+      height: 100%;
+      animation: spinner 5s linear infinite;
+    }
+  }
+}
+
+@keyframes spinner {
+  from {
+    transform: rotate(0deg);
+  }
+
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/client/src/pages/HomePage/HomePage.tsx
+++ b/client/src/pages/HomePage/HomePage.tsx
@@ -1,0 +1,39 @@
+import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { checkAuthentication } from '../../services/auth';
+
+import Logo from '../../assets/logo.png';
+import './HomePage.css';
+
+const HomePage = () => {
+  const [isAuthenticated, setIsAuthenticated] = useState<boolean>(false);
+  const [hasChecked, setHasChecked] = useState<boolean>(false);
+
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    (async () => {
+      const authRes = await checkAuthentication();
+
+      setIsAuthenticated(authRes);
+      setHasChecked(true);
+    })();
+  }, []);
+
+  if (hasChecked) {
+    if (isAuthenticated) {
+      navigate('/feed');
+    } else {
+      navigate('/login');
+    }
+  }
+
+  return (
+    <div className="home-page">
+      <div className="spinner-container">
+        <img src={Logo} alt="logo" />
+      </div>
+    </div>
+  );
+};
+export default HomePage;


### PR DESCRIPTION
- separate the check auth logic from feed page
- single source of truth for feed page path
- avoid user seeing blank flash
now they will see this spinner for 1 second
<img width="333" alt="截屏2023-11-29 21 54 02" src="https://github.com/jianingroja/FamiGO/assets/63893403/058fe69e-393a-4cc4-b70c-b6e175e34195">


not sure it is a best solution though, for now i think it's ok.

resolve #70 