### PR TITLE
deploy/fe: edit cors config

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -7,18 +7,12 @@ const app = express();
 
 app.use(
   cors({
-    origin: 'http://localhost:5173',
     credentials: true,
     methods: ['GET', 'POST', 'PUT', 'DELETE'],
   })
 );
 app.use(express.json());
 app.use(cookieParser());
-
-// app.use((req, _res, next) => {
-//   console.log(`Received request: ${req.method} ${req.path}`);
-//   next();
-// });
 
 app.use(router);
 


### PR DESCRIPTION
remove the `cors: http://localhost:5173` restriction, because the deployed frontend requests come from a different domain.